### PR TITLE
⚡ 列挙型の追加とCHaserConnectの修正

### DIFF
--- a/Src/CHaserConnect.rb
+++ b/Src/CHaserConnect.rb
@@ -208,7 +208,7 @@ class CHaserConnect
   end
 
   # 命令実行のためのメソッド（釧路大会オリジナル）
-  def order(direction, action)
+  def order(action, direction)
     case action
     when 0 # walk
       case direction
@@ -290,7 +290,8 @@ if __FILE__ == $0
       break
     end
 
-    values = target.searchUp
+#    values = target.searchUp
+    values = target.order(2, 2)
     if values[0] == 0
       break
     end

--- a/Src/CHaserTools.rb
+++ b/Src/CHaserTools.rb
@@ -28,7 +28,7 @@ end
 module MapInfo
 
     AISLE = 0
-    CHARACTER = 1
+    ENEMY = 1
     BLOCK = 2
     ITEM = 3
 

--- a/Src/CHaserTools.rb
+++ b/Src/CHaserTools.rb
@@ -1,5 +1,5 @@
-# CHaserの行動を数字にまとめる列挙型
-module CHaserActions
+# 行動を数字にまとめる列挙型(order関数用)
+module Action
     
     WALK = 0
     LOOK = 1
@@ -9,8 +9,8 @@ module CHaserActions
 end 
 
 
-# CHaserの行動方向とその処理をまとめる列挙型
-module CHaserDirections
+# 行動方向とその処理をまとめる列挙型(order関数用)
+module Direction
 
     UP = 2
     LEFT = 4

--- a/Src/CHaserTools.rb
+++ b/Src/CHaserTools.rb
@@ -1,4 +1,4 @@
-#CHaserの行動を数字にまとめる列挙型
+# CHaserの行動を数字にまとめる列挙型
 module CHaserActions
     
     WALK = 0
@@ -9,7 +9,7 @@ module CHaserActions
 end 
 
 
-#CHaserの行動方向とその処理をまとめる列挙型
+# CHaserの行動方向とその処理をまとめる列挙型
 module CHaserDirections
 
     UP = 2
@@ -22,4 +22,14 @@ module CHaserDirections
     end
     
     module_function :Reverse
+end
+
+# サーバから取得できる情報をまとめる列挙型
+module MapInfo
+
+    AISLE = 0
+    CHARACTER = 1
+    BLOCK = 2
+    ITEM = 3
+
 end

--- a/Src/CHaserTools.rb
+++ b/Src/CHaserTools.rb
@@ -27,7 +27,7 @@ end
 # サーバから取得できる情報をまとめる列挙型
 module MapInfo
 
-    AISLE = 0
+    FLOOR = 0
     ENEMY = 1
     BLOCK = 2
     ITEM = 3

--- a/Src/practice.rb
+++ b/Src/practice.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-require  'CHaserConnect.rb' #呼び出すおまじない
+#require  'CHaserConnect.rb' #呼び出すおまじない
+require  '.\CHaserConnect.rb' #呼び出すおまじない
 
 # 書き換えない
 target = CHaserConnect.new("prac") # ()の中好きな名前
@@ -18,6 +19,14 @@ loop do # ここからループ
 #-----ここまで書き換えない-----
 
 #ここに処理を書く
+
+#values = target.walkUp
+if values[2] == 2
+  values = target.walkRight
+else 
+  values = target.walkUp
+end
+
 
 #---------ここから---------
   if values[0] == 0

--- a/Src/practice.rb
+++ b/Src/practice.rb
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-require  'CHaserConnect.rb' #呼び出すおまじない
+require 'CHaserConnect.rb' #呼び出すおまじない
+require 'CHaserTools.rb'
+
+include Action
+include Direction
+include MapInfo
 
 # 書き換えない
 target = CHaserConnect.new("prac") # ()の中好きな名前
@@ -18,14 +23,6 @@ loop do # ここからループ
 #-----ここまで書き換えない-----
 
 #ここに処理を書く
-
-#values = target.walkUp
-if values[2] == 2
-  values = target.walkRight
-else 
-  values = target.walkUp
-end
-
 
 #---------ここから---------
   if values[0] == 0


### PR DESCRIPTION
- マップ情報を列挙型で管理した方が見通しが良くなるので追加
- CHaserConnectのサンプル動作をorder関数を用いたものに変更
- 列挙型の命名規則として頭にCHaserをつけていたが冗長になり見通しも悪いため変更